### PR TITLE
adds block authorizing minting to call token-v2 functions in some unit tests

### DIFF
--- a/koku/tests/minting_test.ts
+++ b/koku/tests/minting_test.ts
@@ -138,6 +138,13 @@ Clarinet.test({
     fn(chain: Chain, accounts: Map<string, Account>) {
         const deployer = accounts.get('deployer')!;
 
+        const authorizationBlock = chain.mineBlock([
+            Tx.contractCall('token-v2',
+                            'add-authorized-contract',
+                            [types.principal(`${deployer.address}.minting`)],
+                            deployer.address)
+        ]);
+
         const maxTokensToMint = 21_000_000_000_000;
 
         let remainingTokensToMint = chain.callReadOnlyFn('minting', 'get-remaining-tokens-to-mint', [], deployer.address);
@@ -221,6 +228,13 @@ Clarinet.test({
         const deployer = accounts.get('deployer')!;
         const wallet1 = accounts.get('wallet_1')!;
         const wallet2 = accounts.get('wallet_2')!;
+
+        const authorizationBlock = chain.mineBlock([
+            Tx.contractCall('token-v2',
+                            'add-authorized-contract',
+                            [types.principal(`${deployer.address}.minting`)],
+                            deployer.address)
+        ]);
 
         const maxTokensToMint = 21_000_000_000_000;
 

--- a/koku/tests/token-v2_test.ts
+++ b/koku/tests/token-v2_test.ts
@@ -175,6 +175,13 @@ Clarinet.test({
         const deployer = accounts.get('deployer')!;
         const wallet1 = accounts.get('wallet_1')!;
 
+        const authorizationBlock = chain.mineBlock([
+            Tx.contractCall('token-v2',
+                            'add-authorized-contract',
+                            [types.principal(`${deployer.address}.minting`)],
+                            deployer.address)
+        ]);
+
         let mintingAuthorization = chain.callReadOnlyFn('token-v2', 'is-authorized', [types.principal(`${deployer.address}.minting`)], deployer.address);
         mintingAuthorization.result.expectBool(true);
 
@@ -252,6 +259,13 @@ Clarinet.test({
         const wallet1 = accounts.get('wallet_1')!;
         const wallet2 = accounts.get('wallet_2')!;
 
+        const authorizationBlock = chain.mineBlock([
+            Tx.contractCall('token-v2',
+                            'add-authorized-contract',
+                            [types.principal(`${deployer.address}.minting`)],
+                            deployer.address)
+        ]);
+
         const block1 = chain.mineBlock([
             Tx.contractCall('minting', 'mint', [types.uint(50), types.principal(wallet1.address)], deployer.address)
         ]);
@@ -292,6 +306,13 @@ Clarinet.test({
         const wallet1 = accounts.get('wallet_1')!;
         const wallet2 = accounts.get('wallet_2')!;
         const wallet3 = accounts.get('wallet_3')!;
+
+        const authorizationBlock = chain.mineBlock([
+            Tx.contractCall('token-v2',
+                            'add-authorized-contract',
+                            [types.principal(`${deployer.address}.minting`)],
+                            deployer.address)
+        ]);
 
         const block1 = chain.mineBlock([
             Tx.contractCall('minting', 'mint', [types.uint(100), types.principal(wallet1.address)], deployer.address),
@@ -370,6 +391,13 @@ Clarinet.test({
 
         const deployer = accounts.get('deployer')!;
         const wallet1 = accounts.get('wallet_1')!;
+
+        const authorizationBlock = chain.mineBlock([
+            Tx.contractCall('token-v2',
+                            'add-authorized-contract',
+                            [types.principal(`${deployer.address}.minting`)],
+                            deployer.address)
+        ]);
 
         const block1 = chain.mineBlock([
             Tx.contractCall('token-v2', 'mint', [types.uint(100), types.principal(deployer.address)], deployer.address)


### PR DESCRIPTION
This small PR allows us to not have a toplevel `contract-call?` inside `minting.clar` to authorize it to call `token-v2` functions.
It accomplishes that by introducing an initial authorization block in some unit tests.